### PR TITLE
Add speaker/company name to session card

### DIFF
--- a/src/components/SessionCard.tsx
+++ b/src/components/SessionCard.tsx
@@ -96,6 +96,25 @@ export default function SessionCard({
             {session.name}
           </h3>
 
+          {session.company?.name && (
+            <div className="text-xs font-medium text-gray-900 mb-2">
+              {session.company.name}
+            </div>
+          )}
+
+          {firstSpeaker && (
+            <div className="mb-3">
+              <div className="text-xs font-medium text-gray-900">
+                {firstSpeaker.name}
+              </div>
+              {firstSpeaker.company?.name && (
+                <div className="text-xs font-medium text-gray-900 mt-1">
+                  {firstSpeaker.company.name}
+                </div>
+              )}
+            </div>
+          )}
+
           <div className="text-xs text-gray-600 mb-2 space-y-1">
             <div className="flex items-center gap-1.5 flex-wrap">
               <Calendar
@@ -186,9 +205,9 @@ export default function SessionCard({
                     <div className="text-xs font-medium text-gray-800 truncate">
                       {speaker.name}
                     </div>
-                    {speaker.title && (
+                    {(speaker.company?.name || speaker.title) && (
                       <div className="text-xs text-gray-500 truncate">
-                        {speaker.title}
+                        {speaker.company?.name || speaker.title}
                       </div>
                     )}
                   </div>


### PR DESCRIPTION
Closes #46 

<img width="1196" height="805" alt="imagem_2026-04-13_123721870" src="https://github.com/user-attachments/assets/22894cd8-8e81-4afe-836c-be946a3876ec" />
<img width="1248" height="770" alt="imagem_2026-04-13_123828158" src="https://github.com/user-attachments/assets/c7516e73-1ecf-4fdc-85a3-8119ccc9f8bf" />
<img width="1237" height="555" alt="imagem_2026-04-13_123843165" src="https://github.com/user-attachments/assets/0ed0b291-dfe0-4d72-8e51-c8626476d469" />

Was this what you had in mind?